### PR TITLE
VOT-26

### DIFF
--- a/src/main/java/com/votify/controllers/AuthController.java
+++ b/src/main/java/com/votify/controllers/AuthController.java
@@ -34,26 +34,24 @@ public class AuthController {
                                     @ExampleObject(name = "Missing required fields",
                                             value = "{\"message\": \"Email and password are required\"}"),
                                     @ExampleObject(name = "Invalid email format",
-                                            value = "{\"message\": \"Email format is incorrect\"}"),
-                                    @ExampleObject(name = "Incorrect email or password",
-                                            value = "{\"message\": \"Email or password does not match\"}")
+                                            value = "{\"message\": \"Email format is incorrect\"}")
                             })
             ),
-            @ApiResponse(responseCode = "404", description = "User not found",
+            @ApiResponse(responseCode = "401", description = "Invalid credentials",
                     content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(name = "UserNotFound",
-                                    value = "{\"message\": \"User not found\"}")
+                            examples = @ExampleObject(name = "Sending Incorrect Data",
+                                    value = "{\"message\": \"Email or password does not match\"}")
                     )
             ),
-            @ApiResponse(responseCode = "403", description = "Inactive user",
+            @ApiResponse(responseCode = "403", description = "User deleted",
                     content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(name = "UserInactive",
-                                    value = "{\"message\": \"User is inactive\"}")
+                            examples = @ExampleObject(name = "User Deleted",
+                                    value = "{\"message\": \"This user has been deleted MM/dd/yyyy\"}")
                     )
             ),
             @ApiResponse(responseCode = "500", description = "Unexpected error",
                     content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(name = "UnexpectedError",
+                            examples = @ExampleObject(name = "Unexpected Error",
                                     value = "{\"message\": \"An error occurred during login\"}")
                     )
             )

--- a/src/main/java/com/votify/exceptions/UserDeletedException.java
+++ b/src/main/java/com/votify/exceptions/UserDeletedException.java
@@ -1,0 +1,7 @@
+package com.votify.exceptions;
+
+public class UserDeletedException extends RuntimeException {
+    public UserDeletedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/votify/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/votify/handlers/GlobalExceptionHandler.java
@@ -35,6 +35,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CustomErrorResponse> handlerUserNotFound(UserNotFoundException ex) {
         return new ResponseEntity<>(new CustomErrorResponse(ex.getMessage()), HttpStatus.NOT_FOUND);
     }
+    @ExceptionHandler(UserDeletedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<CustomErrorResponse> handlerUserNotFound(UserDeletedException ex) {
+        return new ResponseEntity<>(new CustomErrorResponse(ex.getMessage()), HttpStatus.FORBIDDEN);
+    }
 
     @ExceptionHandler(ValidationErrorException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/votify/models/BaseEntity.java
+++ b/src/main/java/com/votify/models/BaseEntity.java
@@ -1,8 +1,11 @@
 package com.votify.models;
 import jakarta.persistence.*;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 
 @MappedSuperclass
+@Getter
 public abstract class BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/src/main/java/com/votify/services/AuthService.java
+++ b/src/main/java/com/votify/services/AuthService.java
@@ -42,10 +42,14 @@ public class AuthService implements UserDetailsService {
         } else if (!loginDTO.email().matches("^[^@]+@[^@]+$")) {
             throw new InvalidCredentialsException("Email format is incorrect");
         }
-        UserModel user = userService.loadUserByLogin(loginDTO.email());
 
-        if (user == null)
-            throw new UserNotFoundException();
+        UserModel user;
+
+        try {
+            user = userService.loadUserByLogin(loginDTO.email());
+        } catch (UserNotFoundException e) {
+            throw new InvalidCredentialsException("Email or password does not match");
+        }
 
         if (!new BCryptPasswordEncoder().matches(loginDTO.password(), user.getPassword())) {
             throw new InvalidCredentialsException("Email or password does not match");

--- a/src/main/java/com/votify/services/AuthService.java
+++ b/src/main/java/com/votify/services/AuthService.java
@@ -3,6 +3,7 @@ package com.votify.services;
 import com.votify.dtos.requests.AuthenticationRequestDTO;
 import com.votify.exceptions.InvalidCredentialsException;
 import com.votify.exceptions.InvalidResetCodeException;
+import com.votify.exceptions.UserDeletedException;
 import com.votify.exceptions.UserNotFoundException;
 import com.votify.models.UserModel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Service
 public class AuthService implements UserDetailsService {
@@ -51,8 +53,12 @@ public class AuthService implements UserDetailsService {
             throw new InvalidCredentialsException("Email or password does not match");
         }
 
-        if (!new BCryptPasswordEncoder().matches(loginDTO.password(), user.getPassword())) {
+        if (!new BCryptPasswordEncoder().matches(loginDTO.password(), user.getPassword()))
             throw new InvalidCredentialsException("Email or password does not match");
+
+        if (user.isDeleted()) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");
+            throw new UserDeletedException("this user has been deleted " + user.getDeletedAt().format(formatter));
         }
     }
 


### PR DESCRIPTION
## Consertando brecha na segurança :crossed_swords: 
    
- Cenário: Ao tentar logar com um email que não existe agora retorna `401 Invalid credentials`

- Cenário 2: Se o usuário enviar um email que existe mas que não coincide com a senha do banco retorna `401 Invalid credentials`

### Exemplo de resposta: 
```json
{
  "message": "Email and/or password does not match"
}
```

## Tratamento do usuário deletado :ballot_box: 

- Cenário: Usuário tem seus dados cadastrados no sistema, mas está deletado. Quando for realizar login agora retorna `403 User deleted`

### Exemplo de resposta: 
```json
{
  "message": "This user has been deleted MM/dd/yyyy"
}
```
